### PR TITLE
Fix telnet troubleshooting instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A collection of various templates that can be used for troubleshooting different
 
 ## Network Troubleshooting with Telnet
 
-+ `oc new-project openshift-troubleshooting-telnet`
++ `oc new-project telnet-troubleshooting-openshift`
 + `oc create -f https://raw.githubusercontent.com/openshift-cs/OpenShift-Troubleshooting-Templates/master/busybox-telnet.yaml`
 + `oc rsh busybox-telnet`
     > / $ telnet \<HOST\> \<PORT\>
-+ `oc delete project openshift-troubleshooting-telnet`
++ `oc delete project telnet-troubleshooting-openshift`


### PR DESCRIPTION
Non-privileged accounts are unable to create projects
that start with "openshift", this fixes the instructions
to use a project that doesn't start with "openshift"