### PR TITLE
remove the hard set version for the vpc module

### DIFF
--- a/rosa-hcp-terraform/setup-vpc.tf
+++ b/rosa-hcp-terraform/setup-vpc.tf
@@ -42,7 +42,6 @@ provider "aws" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.14.2"
 
   name = "${var.cluster_name}-vpc"
   cidr = "10.0.0.0/16"


### PR DESCRIPTION
With AWS' deprecation of EC2-classic use of *_classiclink in terraform modules was also deprecated. With the release of the 5.0.0 AWS terraform module it's now removed and using it causes plan creation to fail. setup-vpc was set to use version 3.14.2 of the vpc module which used classiclink. VPC module 4+ is needed so we need to remove the hard set variable holding that back or the VPC terraform option steps in the docs won't work anymore. This change removes that hard set version and allows it to use 4+