### PR TITLE
Fix bug where all default security group rules are revoked

### DIFF
--- a/rosa-hcp-terraform/setup-vpc.tf
+++ b/rosa-hcp-terraform/setup-vpc.tf
@@ -10,7 +10,7 @@ terraform {
 variable "aws_region" {
   type        = string
   description = "The region to create the ROSA cluster in"
-  
+
   validation {
     condition     = contains(["eu-central-1", "eu-west-1", "us-east-1", "us-east-2", "us-west-2"], var.aws_region)
     error_message = "HyperShift is currently only availble in these regions: eu-central-1, eu-west-1, us-east-1, us-east-2, us-west-2."
@@ -18,27 +18,27 @@ variable "aws_region" {
 }
 
 variable "az_ids" {
-  type        = object({
+  type = object({
     eu-west-1 = list(string)
     us-east-1 = list(string)
     us-east-2 = list(string)
     us-west-2 = list(string)
   })
   description = "A list of region-mapped AZ IDs that a subnet should get deployed into"
-  default     = {
+  default = {
     eu-central-1 = ["euc1-az1", "euc1-az2"]
-    eu-west-1 = ["euw1-az1", "euw1-az2"]
-    us-east-1 = ["use1-az1", "use1-az2"]
-    us-east-2 = ["use2-az1", "use2-az2"]
-    us-west-2 = ["usw2-az1", "usw2-az2"]
+    eu-west-1    = ["euw1-az1", "euw1-az2"]
+    us-east-1    = ["use1-az1", "use1-az2"]
+    us-east-2    = ["use2-az1", "use2-az2"]
+    us-west-2    = ["usw2-az1", "usw2-az2"]
   }
 }
 
 variable "cluster_name" {
-    type        = string
-    description = "The name of the ROSA cluster to create"
-    default     = "rosa-cluster"
-  
+  type        = string
+  description = "The name of the ROSA cluster to create"
+  default     = "rosa-cluster"
+
   validation {
     condition     = can(regex("^[a-z][-a-z0-9]{0,13}[a-z0-9]$", var.cluster_name))
     error_message = "ROSA cluster name must be less than 16 characters, be lower case alphanumeric, with only hyphens."
@@ -46,7 +46,7 @@ variable "cluster_name" {
 }
 
 provider "aws" {
-  region  = var.aws_region
+  region = var.aws_region
 }
 
 module "vpc" {
@@ -60,10 +60,11 @@ module "vpc" {
   private_subnets = ["10.0.1.0/24", "10.0.2.0/24"]
   public_subnets  = ["10.0.101.0/24", "10.0.102.0/24"]
 
-  enable_nat_gateway   = true
-  single_nat_gateway   = true
-  enable_dns_hostnames = true
-  enable_dns_support   = true
+  enable_nat_gateway            = true
+  single_nat_gateway            = true
+  enable_dns_hostnames          = true
+  enable_dns_support            = true
+  manage_default_security_group = false
 }
 
 output "cluster-private-subnet" {


### PR DESCRIPTION
In v4.0.0 of the vpc module we use, manage_default_security_group now defaults to true
(https://github.com/terraform-aws-modules/terraform-aws-vpc/releases/tag/v4.0.0).

This has the effect of immediately revoking all inbound/outbound security group rules on the default security group, which is not suitable for HyperShift until OCPBUGS-11894 is fixed and released.

I also ran `terraform fmt`