### PR TITLE
Fixed missing "eu-central-1" reference

### DIFF
--- a/rosa-hcp-terraform/setup-vpc.tf
+++ b/rosa-hcp-terraform/setup-vpc.tf
@@ -19,6 +19,7 @@ variable "aws_region" {
 
 variable "az_ids" {
   type = object({
+    eu-central-1 = list(string)
     eu-west-1 = list(string)
     us-east-1 = list(string)
     us-east-2 = list(string)


### PR DESCRIPTION
Terraform fails because of this:

```
Plan: 6 to add, 0 to change, 0 to destroy.
╷
│ Error: Invalid index
│ 
│   on setup-vpc.tf line 59, in module "vpc":
│   59:   azs             = var.az_ids[var.aws_region]
│     ├────────────────
│     │ var.aws_region is "eu-central-1"
│     │ var.az_ids is object with 4 attributes
│ 
│ The given key does not identify an element in this collection value.
╵
```

This pull request fixes the issue.