### PR TITLE
fix(add missing eu-central-1 region to az_ids)

### DIFF
--- a/rosa-hcp-terraform/setup-vpc.tf
+++ b/rosa-hcp-terraform/setup-vpc.tf
@@ -19,6 +19,7 @@ variable "aws_region" {
 
 variable "az_ids" {
   type = object({
+    eu-central-1 = list(string)
     eu-west-1 = list(string)
     us-east-1 = list(string)
     us-east-2 = list(string)


### PR DESCRIPTION
Fixes:
```
terraform plan -out rosa.plan -var aws_region=eu-central-1 -var cluster_name=cbusse-hcp

...
Plan: 6 to add, 0 to change, 0 to destroy.
╷
│ Error: Invalid index
│ 
│   on setup-vpc.tf line 59, in module "vpc":
│   59:   azs             = var.az_ids[var.aws_region]
│     ├────────────────
│     │ var.aws_region is "eu-central-1"
│     │ var.az_ids is object with 4 attributes
│ 
│ The given key does not identify an element in this collection value.
╵
```
when creating the terraform plan for eu-central-1